### PR TITLE
[MCP-105] Front end ready for PR.

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,4 @@
+REACT_APP_GRAPHQL_API_URL=http://localhost:4000/
+REACT_APP_MCP_DATA_MAPPING_UTIL=http://localhost:5000/
+
+# Just provide the root with the slash, let the software handle high-level routes like api. 

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -33,9 +33,6 @@ const Nav: React.FC = () => {
           overlayClassName={"nav__menu-overlay"}
           onStateChange={state => handleStateChange(state)}
         >
-          <Link to="/app/rating" onClick={() => setMenuOpen(false)}>
-            {"Go to Rating Page"}
-          </Link>
           <Link to="/app/upload" onClick={() => setMenuOpen(false)}>
             {"Go to Upload Page"}
           </Link>

--- a/src/components/UploadPage/UploadPage.scss
+++ b/src/components/UploadPage/UploadPage.scss
@@ -36,7 +36,16 @@
   }
 
   @include element("upload-notice") {
-    margin-top: 0.5em;
+    margin: 0.5em 0;
+  }
+
+  @include element("file-report") {
+    white-space: pre-wrap;
+    margin: 0 25%;
+  }
+
+  @include element("file-message") {
+    font-size: 1.2em;
   }
 
   @keyframes blinkingText {

--- a/src/components/UploadPage/UploadPage.scss
+++ b/src/components/UploadPage/UploadPage.scss
@@ -29,7 +29,7 @@
     width: 80%;
   }
 
-  @include element("indicator") {
+  @include element("load-indicator") {
     animation: blinkingText 1s infinite;
     margin-top: 0.5em;
     font-weight: bolder;
@@ -44,7 +44,7 @@
     margin: 0 25%;
   }
 
-  @include element("file-message") {
+  @include element("message") {
     font-size: 1.2em;
   }
 

--- a/src/components/UploadPage/UploadPage.scss
+++ b/src/components/UploadPage/UploadPage.scss
@@ -35,7 +35,7 @@
     font-weight: bolder;
   }
 
-  @include element("upload-info") {
+  @include element("upload-notice") {
     margin-top: 0.5em;
   }
 

--- a/src/components/UploadPage/UploadPage.scss
+++ b/src/components/UploadPage/UploadPage.scss
@@ -35,6 +35,10 @@
     font-weight: bolder;
   }
 
+  @include element("upload-info") {
+    margin-top: 0.5em;
+  }
+
   @keyframes blinkingText {
     0% {
       color: $PRIMARY_BODY_TEXT_COLOR;

--- a/src/components/UploadPage/UploadPage.test.tsx
+++ b/src/components/UploadPage/UploadPage.test.tsx
@@ -38,59 +38,59 @@ describe("Component: UploadPage", () => {
     mockDataService.setOutcomeAwait(true);
     const callSpy = mockDataService.postMultipartRequest(
       {},
-      "" + process.env.REACT_APP_MCP_DATA_SOURCE
+      "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
     );
     const wrapper = shallow(<UploadPage />);
     expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual("");
+    expect(wrapper.state("uploadNotice")).toEqual("");
     wrapper.find(".upload-page__file-input").simulate("change", testEvent);
     expect(wrapper.state("loading")).toBe(true);
-    expect(wrapper.state("uploadMessage")).toEqual("");
+    expect(wrapper.state("uploadNotice")).toEqual("");
     expect(callSpy).toHaveBeenCalled();
     await mockDataService.setOutcomeAwait(false);
     expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual("Upload success.");
+    expect(wrapper.state("uploadNotice")).toEqual("Upload success.");
   });
 
-  it("is rejected in it attempts to upload a file", async () => {
-    mockDataService.setOutcomeSetting(Outcome.REJECT);
-    mockDataService.setOutcomeAwait(true);
-    const callSpy = mockDataService.postMultipartRequest(
-      {},
-      "" + process.env.REACT_APP_MCP_DATA_SOURCE
-    );
-    const wrapper = shallow(<UploadPage />);
-    expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual("");
-    wrapper.find(".upload-page__file-input").simulate("change", testEvent);
-    expect(wrapper.state("loading")).toBe(true);
-    expect(wrapper.state("uploadMessage")).toEqual("");
-    expect(callSpy).toHaveBeenCalled();
-    await mockDataService.setOutcomeAwait(false);
-    expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual(
-      "Failed to upload. Something is wrong with the endpoint."
-    );
-  });
+  // it("is rejected in it attempts to upload a file", async () => {
+  //   mockDataService.setOutcomeSetting(Outcome.REJECT);
+  //   mockDataService.setOutcomeAwait(true);
+  //   const callSpy = mockDataService.postMultipartRequest(
+  //     {},
+  //     "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
+  //   );
+  //   const wrapper = shallow(<UploadPage />);
+  //   expect(wrapper.state("loading")).toBe(false);
+  //   expect(wrapper.state("uploadNotice")).toEqual("");
+  //   wrapper.find(".upload-page__file-input").simulate("change", testEvent);
+  //   expect(wrapper.state("loading")).toBe(true);
+  //   expect(wrapper.state("uploadNotice")).toEqual("");
+  //   expect(callSpy).toHaveBeenCalled();
+  //   await mockDataService.setOutcomeAwait(false);
+  //   expect(wrapper.state("loading")).toBe(false);
+  //   expect(wrapper.state("uploadNotice")).toEqual(
+  //     "Failed to upload. Something is wrong with the endpoint."
+  //   );
+  // });
 
-  it("fails in it attempts to upload a file", async () => {
-    mockDataService.setOutcomeSetting(Outcome.FAILURE);
-    mockDataService.setOutcomeAwait(true);
-    const callSpy = mockDataService.postMultipartRequest(
-      {},
-      "" + process.env.REACT_APP_MCP_DATA_SOURCE
-    );
-    const wrapper = shallow(<UploadPage />);
-    expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual("");
-    wrapper.find(".upload-page__file-input").simulate("change", testEvent);
-    expect(wrapper.state("loading")).toBe(true);
-    expect(wrapper.state("uploadMessage")).toEqual("");
-    expect(callSpy).toHaveBeenCalled();
-    await mockDataService.setOutcomeAwait(false);
-    expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadMessage")).toEqual(
-      "Failed to upload due to connectivity issues."
-    );
-  });
+  // it("fails in it attempts to upload a file", async () => {
+  //   mockDataService.setOutcomeSetting(Outcome.FAILURE);
+  //   mockDataService.setOutcomeAwait(true);
+  //   const callSpy = mockDataService.postMultipartRequest(
+  //     {},
+  //     "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
+  //   );
+  //   const wrapper = shallow(<UploadPage />);
+  //   expect(wrapper.state("loading")).toBe(false);
+  //   expect(wrapper.state("uploadNotice")).toEqual("");
+  //   wrapper.find(".upload-page__file-input").simulate("change", testEvent);
+  //   expect(wrapper.state("loading")).toBe(true);
+  //   expect(wrapper.state("uploadNotice")).toEqual("");
+  //   expect(callSpy).toHaveBeenCalled();
+  //   await mockDataService.setOutcomeAwait(false);
+  //   expect(wrapper.state("loading")).toBe(false);
+  //   expect(wrapper.state("uploadNotice")).toEqual(
+  //     "Failed to upload due to connectivity issues."
+  //   );
+  // });
 });

--- a/src/components/UploadPage/UploadPage.test.tsx
+++ b/src/components/UploadPage/UploadPage.test.tsx
@@ -19,11 +19,11 @@ const testEvent = {
 
 const defaultState = function(wrapper: ShallowWrapper) {
   expect(wrapper.state("loading")).toBe(false);
-  expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+  expect(wrapper.find(".upload-page__load-indicator").exists()).toBe(false);
   expect(wrapper.state("uploadNotice")).toEqual("");
   expect(wrapper.find(".upload-page__upload-notice").text()).toEqual("");
   expect(wrapper.state("message")).toEqual("");
-  expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+  expect(wrapper.find(".upload-page__message").text()).toEqual("");
   expect(wrapper.state("fileReport")).toMatchObject({});
   expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
 };
@@ -31,13 +31,13 @@ const defaultState = function(wrapper: ShallowWrapper) {
 const loadingState = function(wrapper: ShallowWrapper) {
   wrapper.find(".upload-page__file-input").simulate("change", testEvent);
   expect(wrapper.state("loading")).toBe(true);
-  expect(wrapper.find(".upload-page__indicator").text()).toEqual(
+  expect(wrapper.find(".upload-page__load-indicator").text()).toEqual(
     "Uploading..."
   );
   expect(wrapper.state("uploadNotice")).toEqual("");
   expect(wrapper.find(".upload-page__upload-notice").text()).toEqual("");
   expect(wrapper.state("message")).toEqual("");
-  expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+  expect(wrapper.find(".upload-page__message").text()).toEqual("");
   expect(wrapper.state("fileReport")).toMatchObject({});
   expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
 };
@@ -71,12 +71,22 @@ describe("Component: UploadPage", () => {
     expect(callSpy).toHaveBeenCalled();
     await mockDataService.setOutcomeAwait(false);
     expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+    expect(wrapper.find(".upload-page__load-indicator").exists()).toBe(false);
     expect(wrapper.state("uploadNotice")).toEqual("Upload success.");
+    expect(wrapper.find(".upload-page__upload-notice").text()).toEqual(
+      "Upload success."
+    );
     expect(wrapper.state("message")).toEqual("Validation report");
+    expect(wrapper.find(".upload-page__message").text()).toEqual(
+      "Validation report"
+    );
     expect(wrapper.state("fileReport")).toMatchObject({
       report: "I am the validator."
     });
+    expect(wrapper.find(".upload-page__error-panel").exists()).toBe(true);
+    expect(wrapper.find(".upload-page__error-panel").text()).toEqual(
+      "I am the validator."
+    );
   });
 
   it("is rejected in it attempts to upload a file", async () => {
@@ -92,7 +102,7 @@ describe("Component: UploadPage", () => {
     expect(callSpy).toHaveBeenCalled();
     await mockDataService.setOutcomeAwait(false);
     expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+    expect(wrapper.find(".upload-page__load-indicator").exists()).toBe(false);
     expect(wrapper.state("uploadNotice")).toEqual(
       "Failed to upload. Something is wrong with the endpoint."
     );
@@ -100,8 +110,9 @@ describe("Component: UploadPage", () => {
       "Failed to upload. Something is wrong with the endpoint."
     );
     expect(wrapper.state("message")).toEqual("Doh!");
-    expect(wrapper.find(".upload-page__file-message").text()).toEqual("Doh!");
+    expect(wrapper.find(".upload-page__message").text()).toEqual("Doh!");
     expect(wrapper.state("fileReport")).toMatchObject({});
+    expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
   });
 
   it("fails in it attempts to upload a file", async () => {
@@ -117,7 +128,7 @@ describe("Component: UploadPage", () => {
     expect(callSpy).toHaveBeenCalled();
     await mockDataService.setOutcomeAwait(false);
     expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+    expect(wrapper.find(".upload-page__load-indicator").exists()).toBe(false);
     expect(wrapper.state("uploadNotice")).toEqual(
       "Failed to upload due to connectivity issues."
     );
@@ -125,7 +136,8 @@ describe("Component: UploadPage", () => {
       "Failed to upload due to connectivity issues."
     );
     expect(wrapper.state("message")).toEqual("");
-    expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+    expect(wrapper.find(".upload-page__message").text()).toEqual("");
     expect(wrapper.state("fileReport")).toMatchObject({});
+    expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
   });
 });

--- a/src/components/UploadPage/UploadPage.test.tsx
+++ b/src/components/UploadPage/UploadPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow, configure } from "enzyme";
+import { shallow, configure, ShallowWrapper } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import ReactDOM from "react-dom";
 import { ApolloProvider } from "@apollo/react-hooks";
@@ -15,6 +15,31 @@ const testEvent = {
     files: ["thetestfile.doc"]
   },
   preventDefault: () => {}
+};
+
+const defaultState = function(wrapper: ShallowWrapper) {
+  expect(wrapper.state("loading")).toBe(false);
+  expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+  expect(wrapper.state("uploadNotice")).toEqual("");
+  expect(wrapper.find(".upload-page__upload-notice").text()).toEqual("");
+  expect(wrapper.state("message")).toEqual("");
+  expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+  expect(wrapper.state("fileReport")).toMatchObject({});
+  expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
+};
+
+const loadingState = function(wrapper: ShallowWrapper) {
+  wrapper.find(".upload-page__file-input").simulate("change", testEvent);
+  expect(wrapper.state("loading")).toBe(true);
+  expect(wrapper.find(".upload-page__indicator").text()).toEqual(
+    "Uploading..."
+  );
+  expect(wrapper.state("uploadNotice")).toEqual("");
+  expect(wrapper.find(".upload-page__upload-notice").text()).toEqual("");
+  expect(wrapper.state("message")).toEqual("");
+  expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+  expect(wrapper.state("fileReport")).toMatchObject({});
+  expect(wrapper.find(".upload-page__error-panel").exists()).toBe(false);
 };
 
 describe("Component: UploadPage", () => {
@@ -41,56 +66,66 @@ describe("Component: UploadPage", () => {
       "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
     );
     const wrapper = shallow(<UploadPage />);
-    expect(wrapper.state("loading")).toBe(false);
-    expect(wrapper.state("uploadNotice")).toEqual("");
-    wrapper.find(".upload-page__file-input").simulate("change", testEvent);
-    expect(wrapper.state("loading")).toBe(true);
-    expect(wrapper.state("uploadNotice")).toEqual("");
+    defaultState(wrapper);
+    loadingState(wrapper);
     expect(callSpy).toHaveBeenCalled();
     await mockDataService.setOutcomeAwait(false);
     expect(wrapper.state("loading")).toBe(false);
+    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
     expect(wrapper.state("uploadNotice")).toEqual("Upload success.");
+    expect(wrapper.state("message")).toEqual("Validation report");
+    expect(wrapper.state("fileReport")).toMatchObject({
+      report: "I am the validator."
+    });
   });
 
-  // it("is rejected in it attempts to upload a file", async () => {
-  //   mockDataService.setOutcomeSetting(Outcome.REJECT);
-  //   mockDataService.setOutcomeAwait(true);
-  //   const callSpy = mockDataService.postMultipartRequest(
-  //     {},
-  //     "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
-  //   );
-  //   const wrapper = shallow(<UploadPage />);
-  //   expect(wrapper.state("loading")).toBe(false);
-  //   expect(wrapper.state("uploadNotice")).toEqual("");
-  //   wrapper.find(".upload-page__file-input").simulate("change", testEvent);
-  //   expect(wrapper.state("loading")).toBe(true);
-  //   expect(wrapper.state("uploadNotice")).toEqual("");
-  //   expect(callSpy).toHaveBeenCalled();
-  //   await mockDataService.setOutcomeAwait(false);
-  //   expect(wrapper.state("loading")).toBe(false);
-  //   expect(wrapper.state("uploadNotice")).toEqual(
-  //     "Failed to upload. Something is wrong with the endpoint."
-  //   );
-  // });
+  it("is rejected in it attempts to upload a file", async () => {
+    mockDataService.setOutcomeSetting(Outcome.REJECT);
+    mockDataService.setOutcomeAwait(true);
+    const callSpy = mockDataService.postMultipartRequest(
+      {},
+      "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
+    );
+    const wrapper = shallow(<UploadPage />);
+    defaultState(wrapper);
+    loadingState(wrapper);
+    expect(callSpy).toHaveBeenCalled();
+    await mockDataService.setOutcomeAwait(false);
+    expect(wrapper.state("loading")).toBe(false);
+    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+    expect(wrapper.state("uploadNotice")).toEqual(
+      "Failed to upload. Something is wrong with the endpoint."
+    );
+    expect(wrapper.find(".upload-page__upload-notice").text()).toEqual(
+      "Failed to upload. Something is wrong with the endpoint."
+    );
+    expect(wrapper.state("message")).toEqual("Doh!");
+    expect(wrapper.find(".upload-page__file-message").text()).toEqual("Doh!");
+    expect(wrapper.state("fileReport")).toMatchObject({});
+  });
 
-  // it("fails in it attempts to upload a file", async () => {
-  //   mockDataService.setOutcomeSetting(Outcome.FAILURE);
-  //   mockDataService.setOutcomeAwait(true);
-  //   const callSpy = mockDataService.postMultipartRequest(
-  //     {},
-  //     "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
-  //   );
-  //   const wrapper = shallow(<UploadPage />);
-  //   expect(wrapper.state("loading")).toBe(false);
-  //   expect(wrapper.state("uploadNotice")).toEqual("");
-  //   wrapper.find(".upload-page__file-input").simulate("change", testEvent);
-  //   expect(wrapper.state("loading")).toBe(true);
-  //   expect(wrapper.state("uploadNotice")).toEqual("");
-  //   expect(callSpy).toHaveBeenCalled();
-  //   await mockDataService.setOutcomeAwait(false);
-  //   expect(wrapper.state("loading")).toBe(false);
-  //   expect(wrapper.state("uploadNotice")).toEqual(
-  //     "Failed to upload due to connectivity issues."
-  //   );
-  // });
+  it("fails in it attempts to upload a file", async () => {
+    mockDataService.setOutcomeSetting(Outcome.FAILURE);
+    mockDataService.setOutcomeAwait(true);
+    const callSpy = mockDataService.postMultipartRequest(
+      {},
+      "" + process.env.REACT_APP_MCP_DATA_MAPPING_UTIL
+    );
+    const wrapper = shallow(<UploadPage />);
+    defaultState(wrapper);
+    loadingState(wrapper);
+    expect(callSpy).toHaveBeenCalled();
+    await mockDataService.setOutcomeAwait(false);
+    expect(wrapper.state("loading")).toBe(false);
+    expect(wrapper.find(".upload-page__indicator").exists()).toBe(false);
+    expect(wrapper.state("uploadNotice")).toEqual(
+      "Failed to upload due to connectivity issues."
+    );
+    expect(wrapper.find(".upload-page__upload-notice").text()).toEqual(
+      "Failed to upload due to connectivity issues."
+    );
+    expect(wrapper.state("message")).toEqual("");
+    expect(wrapper.find(".upload-page__file-message").text()).toEqual("");
+    expect(wrapper.state("fileReport")).toMatchObject({});
+  });
 });

--- a/src/components/UploadPage/UploadPage.tsx
+++ b/src/components/UploadPage/UploadPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DataService } from "../../services/data/DataService";
+import { dataService } from "../../services/data/DataService";
 
 type Props = {};
 
@@ -31,10 +31,11 @@ class UploadPage extends React.Component<Props, State> {
     if (event.target.files && event.target.files[0]) {
       const filename = event.target.files[0].name;
       this.setState({ loading: true, uploadNotice: "", message: "" });
-      DataService.postMultipartRequest({
-        file: event.target.files[0],
-        filename
-      })
+      dataService
+        .postMultipartRequest({
+          file: event.target.files[0],
+          filename
+        })
         .then(response => {
           if (response.status !== 200) {
             // A response of *any* kind is technically success.
@@ -81,7 +82,7 @@ class UploadPage extends React.Component<Props, State> {
           />
         </form>
         {this.state.loading ? (
-          <div className="upload-page__indicator">Uploading...</div>
+          <div className="upload-page__load-indicator">Uploading...</div>
         ) : (
           ""
         )}
@@ -89,13 +90,14 @@ class UploadPage extends React.Component<Props, State> {
           {this.state.uploadNotice}
         </div>
         <div className="upload-page__file-report">
-          <span className="upload-page__file-message">
-            {this.state.message}
-          </span>
+          <span className="upload-page__message">{this.state.message}</span>
           <div className="upload-page__file-breakdown">
             {Object.keys(this.state.fileReport).map(
               (reportKey: string, index: number) => (
-                <div key={`upload-page-file-report-${index}`}>
+                <div
+                  className="upload-page__error-panel"
+                  key={`upload-page__file-report-${index}`}
+                >
                   {this.state.fileReport[reportKey]}
                 </div>
               )

--- a/src/components/UploadPage/UploadPage.tsx
+++ b/src/components/UploadPage/UploadPage.tsx
@@ -7,6 +7,11 @@ interface State {
   loading: Boolean;
   uploadNotice: string;
   message: string;
+  fileReport: FileReport;
+}
+
+interface FileReport {
+  [key: string]: any;
 }
 
 class UploadPage extends React.Component<Props, State> {
@@ -15,7 +20,8 @@ class UploadPage extends React.Component<Props, State> {
     this.state = {
       loading: false,
       uploadNotice: "",
-      message: ""
+      message: "",
+      fileReport: {}
     };
     this.onUploadFile = this.onUploadFile.bind(this);
   }
@@ -36,21 +42,24 @@ class UploadPage extends React.Component<Props, State> {
               loading: false,
               uploadNotice:
                 "Failed to upload. Something is wrong with the endpoint.",
-              message: response.message
+              message: response.message,
+              fileReport: response.fileReport
             });
             return;
           }
           this.setState({
             loading: false,
             uploadNotice: "Upload success.",
-            message: response.message
+            message: response.message + ":",
+            fileReport: response.fileReport
           });
         })
         .catch(() => {
           this.setState({
             loading: false,
             uploadNotice: "Failed to upload due to connectivity issues.",
-            message: ""
+            message: "",
+            fileReport: {}
           });
         });
     }
@@ -79,7 +88,24 @@ class UploadPage extends React.Component<Props, State> {
         <div className="upload-page__upload-notice">
           {this.state.uploadNotice}
         </div>
-        <div className="upload-page__message">{this.state.message}</div>
+        <div className="upload-page__file-report">
+          <span className="upload-page__file-message">
+            {this.state.message}
+          </span>
+          {this.state.fileReport ? (
+            <div className="upload-page__file-breakdown">
+              {Object.keys(this.state.fileReport).map(
+                (reportKey: string, index: number) => (
+                  <div key={`upload-page-file-report-${index}`}>
+                    {this.state.fileReport[reportKey]}
+                  </div>
+                )
+              )}
+            </div>
+          ) : (
+            ""
+          )}
+        </div>
       </div>
     );
   }

--- a/src/components/UploadPage/UploadPage.tsx
+++ b/src/components/UploadPage/UploadPage.tsx
@@ -43,14 +43,14 @@ class UploadPage extends React.Component<Props, State> {
               uploadNotice:
                 "Failed to upload. Something is wrong with the endpoint.",
               message: response.message,
-              fileReport: response.fileReport
+              fileReport: {}
             });
             return;
           }
           this.setState({
             loading: false,
             uploadNotice: "Upload success.",
-            message: response.message + ":",
+            message: response.message,
             fileReport: response.fileReport
           });
         })
@@ -92,19 +92,15 @@ class UploadPage extends React.Component<Props, State> {
           <span className="upload-page__file-message">
             {this.state.message}
           </span>
-          {this.state.fileReport ? (
-            <div className="upload-page__file-breakdown">
-              {Object.keys(this.state.fileReport).map(
-                (reportKey: string, index: number) => (
-                  <div key={`upload-page-file-report-${index}`}>
-                    {this.state.fileReport[reportKey]}
-                  </div>
-                )
-              )}
-            </div>
-          ) : (
-            ""
-          )}
+          <div className="upload-page__file-breakdown">
+            {Object.keys(this.state.fileReport).map(
+              (reportKey: string, index: number) => (
+                <div key={`upload-page-file-report-${index}`}>
+                  {this.state.fileReport[reportKey]}
+                </div>
+              )
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/UploadPage/UploadPage.tsx
+++ b/src/components/UploadPage/UploadPage.tsx
@@ -67,7 +67,9 @@ class UploadPage extends React.Component<Props, State> {
         ) : (
           ""
         )}
-        {this.state.uploadMessage}
+        <div className="upload-page__upload-info">
+          {this.state.uploadMessage}
+        </div>
       </div>
     );
   }

--- a/src/components/UploadPage/UploadPage.tsx
+++ b/src/components/UploadPage/UploadPage.tsx
@@ -5,7 +5,8 @@ type Props = {};
 
 interface State {
   loading: Boolean;
-  uploadMessage: string;
+  uploadNotice: string;
+  message: string;
 }
 
 class UploadPage extends React.Component<Props, State> {
@@ -13,7 +14,8 @@ class UploadPage extends React.Component<Props, State> {
     super(props);
     this.state = {
       loading: false,
-      uploadMessage: ""
+      uploadNotice: "",
+      message: ""
     };
     this.onUploadFile = this.onUploadFile.bind(this);
   }
@@ -22,27 +24,33 @@ class UploadPage extends React.Component<Props, State> {
     event.preventDefault();
     if (event.target.files && event.target.files[0]) {
       const filename = event.target.files[0].name;
-      this.setState({ loading: true });
+      this.setState({ loading: true, uploadNotice: "", message: "" });
       DataService.postMultipartRequest({
         file: event.target.files[0],
         filename
       })
         .then(response => {
-          if (response.status !== 204) {
+          if (response.status !== 200) {
             // A response of *any* kind is technically success.
             this.setState({
               loading: false,
-              uploadMessage:
-                "Failed to upload. Something is wrong with the endpoint."
+              uploadNotice:
+                "Failed to upload. Something is wrong with the endpoint.",
+              message: response.message
             });
             return;
           }
-          this.setState({ loading: false, uploadMessage: "Upload success." });
+          this.setState({
+            loading: false,
+            uploadNotice: "Upload success.",
+            message: response.message
+          });
         })
         .catch(() => {
           this.setState({
             loading: false,
-            uploadMessage: "Failed to upload due to connectivity issues."
+            uploadNotice: "Failed to upload due to connectivity issues.",
+            message: ""
           });
         });
     }
@@ -60,6 +68,7 @@ class UploadPage extends React.Component<Props, State> {
             className="upload-page__file-input"
             onChange={this.onUploadFile}
             type="file"
+            multiple
           />
         </form>
         {this.state.loading ? (
@@ -67,9 +76,10 @@ class UploadPage extends React.Component<Props, State> {
         ) : (
           ""
         )}
-        <div className="upload-page__upload-info">
-          {this.state.uploadMessage}
+        <div className="upload-page__upload-notice">
+          {this.state.uploadNotice}
         </div>
+        <div className="upload-page__message">{this.state.message}</div>
       </div>
     );
   }

--- a/src/models/Call.tsx
+++ b/src/models/Call.tsx
@@ -38,13 +38,12 @@ export class Header {
 /**
  * Handles the de-jsonifying of a response. May move to util later.
  * @param response
- */
-export function handleResponse(response: any) {
-  return response
-    .json()
-    .then((data: any) => ({
-      status: response.status,
-      message: data.message,
-      fileReport: data.files
-    }));
-}
+//  */
+// export function handleResponse(response: any) {
+//   return response
+//     .json()
+//     .then((data: any) => ({
+//       status: response.status,
+//       message: data.message
+//     }));
+// }

--- a/src/models/Call.tsx
+++ b/src/models/Call.tsx
@@ -2,7 +2,7 @@ export default class Call {
   constructor(
     public method: string,
     public header: Header,
-    public body?: string
+    public body?: any
   ) {}
 
   public static getCall(): Call {
@@ -11,6 +11,14 @@ export default class Call {
 
   public static postCall(body: object): Call {
     return new Call("POST", Header.basicHeader(), JSON.stringify(body));
+  }
+
+  public static postForm(body: object): Call {
+    return new Call(
+      "POST",
+      new Header(`Bearer {token}`, "form/multipart"),
+      body
+    );
   }
 }
 
@@ -25,4 +33,14 @@ export class Header {
   public static basicHeader(): Header {
     return new Header(`Bearer {token}`, "application/json");
   }
+}
+
+/**
+ * Handles the de-jsonifying of a response. May move to util later.
+ * @param response
+ */
+export function handleResponse(response: any) {
+  return response
+    .json()
+    .then((data: any) => ({ status: response.status, message: data.message }));
 }

--- a/src/models/Call.tsx
+++ b/src/models/Call.tsx
@@ -42,5 +42,9 @@ export class Header {
 export function handleResponse(response: any) {
   return response
     .json()
-    .then((data: any) => ({ status: response.status, message: data.message }));
+    .then((data: any) => ({
+      status: response.status,
+      message: data.message,
+      fileReport: data.files
+    }));
 }

--- a/src/services/data/DataService.mock.tsx
+++ b/src/services/data/DataService.mock.tsx
@@ -19,11 +19,18 @@ export class MockDataService extends MockSettings {
     if (this.outcomeSetting === Outcome.SUCCESS) {
       callSpy.mockResolvedValue(
         Promise.resolve({
-          status: 200
+          status: 200,
+          message: "Validation report",
+          fileReport: { report: "I am the validator." }
         })
       );
     } else if (this.outcomeSetting === Outcome.REJECT) {
-      this.defaultRejection(callSpy);
+      callSpy.mockResolvedValue(
+        Promise.resolve({
+          status: 500,
+          message: "Doh!"
+        })
+      );
     } else if (this.outcomeSetting === Outcome.FAILURE) {
       this.defaultFailure(callSpy);
     } else {

--- a/src/services/data/DataService.mock.tsx
+++ b/src/services/data/DataService.mock.tsx
@@ -1,6 +1,6 @@
 import { MockSettings } from "../../util/MockSettings";
 import { Outcome } from "../../util/Constants";
-import { DataService } from "./DataService";
+import { dataService } from "./DataService";
 
 /**
  * The mock module is used as part of testing other modules
@@ -15,7 +15,7 @@ export class MockDataService extends MockSettings {
   }
 
   postMultipartRequest(data: any, fullURI: string) {
-    const callSpy = jest.spyOn(DataService, "postMultipartRequest");
+    const callSpy = jest.spyOn(dataService, "postMultipartRequest");
     if (this.outcomeSetting === Outcome.SUCCESS) {
       callSpy.mockResolvedValue(
         Promise.resolve({

--- a/src/services/data/DataService.mock.tsx
+++ b/src/services/data/DataService.mock.tsx
@@ -19,7 +19,7 @@ export class MockDataService extends MockSettings {
     if (this.outcomeSetting === Outcome.SUCCESS) {
       callSpy.mockResolvedValue(
         Promise.resolve({
-          status: 204
+          status: 200
         })
       );
     } else if (this.outcomeSetting === Outcome.REJECT) {

--- a/src/services/data/DataService.test.tsx
+++ b/src/services/data/DataService.test.tsx
@@ -4,7 +4,9 @@ describe("Service: DataService", () => {
   describe("#postMultipartRequest", () => {
     describe("during success", () => {
       let DataServiceSpy = jest.spyOn(DataService, "postMultipartRequest");
-      it("should call the endpoint and return a 204", () => {});
+      it("should call the endpoint and return a 200", () => {});
+      expect(true);
+      expect(DataServiceSpy).toBeTruthy(); // This does nothing.
     });
   });
 });

--- a/src/services/data/DataService.test.tsx
+++ b/src/services/data/DataService.test.tsx
@@ -1,9 +1,9 @@
-import { DataService } from "./DataService";
+import { dataService } from "./DataService";
 
 describe("Service: DataService", () => {
   describe("#postMultipartRequest", () => {
     describe("during success", () => {
-      let DataServiceSpy = jest.spyOn(DataService, "postMultipartRequest");
+      let DataServiceSpy = jest.spyOn(dataService, "postMultipartRequest");
       it("should call the endpoint and return a 200", () => {});
       expect(true);
       expect(DataServiceSpy).toBeTruthy(); // This does nothing.

--- a/src/services/data/DataService.tsx
+++ b/src/services/data/DataService.tsx
@@ -1,5 +1,5 @@
 import Call from "../../models/Call";
-import { handleResponse } from "../../models/Call";
+// import { handleResponse } from "../../models/Call";
 
 /**
  * Data Service, named in the assumption of a unique set of REST calls.
@@ -12,6 +12,12 @@ export class DataService {
         process.env.REACT_APP_MCP_DATA_MAPPING_UTIL + "api/excel/jsontoexcel";
     }
     formData.append("files", data.file);
-    return fetch(fullURI, Call.postForm(formData)).then(handleResponse);
+    return fetch(fullURI, Call.postForm(formData)).then(response => {
+      return response.json().then((data: any) => ({
+        status: response.status,
+        message: data.message,
+        fileReport: data.files
+      }));
+    });
   }
 }

--- a/src/services/data/DataService.tsx
+++ b/src/services/data/DataService.tsx
@@ -1,4 +1,5 @@
 import Call from "../../models/Call";
+import { handleResponse } from "../../models/Call";
 
 /**
  * Data Service, named in the assumption of a unique set of REST calls.
@@ -7,11 +8,10 @@ export class DataService {
   static postMultipartRequest(data: any, fullURI?: string): Promise<any> {
     const formData = new FormData();
     if (fullURI === undefined) {
-      fullURI = process.env.REACT_APP_MCP_DATA_SOURCE + "files";
+      fullURI =
+        process.env.REACT_APP_MCP_DATA_MAPPING_UTIL + "api/excel/jsontoexcel";
     }
-    Object.keys(data).forEach((name: string) =>
-      formData.append(name, data[name])
-    );
-    return fetch(fullURI, Call.postCall(formData));
+    formData.append("files", data.file);
+    return fetch(fullURI, Call.postForm(formData)).then(handleResponse);
   }
 }

--- a/src/services/data/DataService.tsx
+++ b/src/services/data/DataService.tsx
@@ -4,8 +4,14 @@ import Call from "../../models/Call";
 /**
  * Data Service, named in the assumption of a unique set of REST calls.
  */
-export class DataService {
-  static postMultipartRequest(data: any, fullURI?: string): Promise<any> {
+class DataService {
+  baseURI: string;
+
+  constructor(baseURI: string) {
+    this.baseURI = baseURI;
+  }
+
+  postMultipartRequest(data: any, fullURI?: string): Promise<any> {
     const formData = new FormData();
     if (fullURI === undefined) {
       fullURI =
@@ -21,3 +27,7 @@ export class DataService {
     });
   }
 }
+
+export const dataService = new DataService(
+  process.env.REACT_APP_MCP_DATA_MAPPING_UTIL || ""
+);


### PR DESCRIPTION
### Related tickets:
MCP-105.

### What's changing? Any breaking changes?
You'll actually be testing the whole thing, not just this ticket. 

### Manual test cases?
Run `yarn test` to view all tests. Run `yarn start`, and click on the top right nav bar to go to the upload page. Select a file and see that it attempts to upload. We're awaiting Tyler's completion of the PyFlask endpoint for this. 

The interesting thing about this project is the homebrew test harness via `MockSettings.tsx`. This is an extendable class that can be used to emulate an existing service and return values for the Enzyme tests. Per @orndorffgrant's and my own frustrations with IRT, I create a manual await option that will pause fetch requests until we finish doing all our expectations, and then when flipped will `await` the returned result at (almost) your own leisure and not when the delay timer runs out. This allows us to step into and actually test load states in a way that I feel is easier, faster, and less spray-and-pray regarding delay times. 

### Any additional context/background?


### Screenshots (if appropriate):
-
