### PR TITLE
[MCP-206] Changes to reflect the backend's new labels and the object_…

### DIFF
--- a/src/components/UploadPage/components/UploadErrorReport/UploadErrorReport.test.tsx
+++ b/src/components/UploadPage/components/UploadErrorReport/UploadErrorReport.test.tsx
@@ -55,7 +55,7 @@ describe("Component: UploadErrorRow", () => {
     expect(
       wrapper.find(".upload-error-report__arrow").hasClass("down")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(5);
+    expect(wrapper.find(UploadErrorRow).length).toBe(7);
 
     wrapper.find(".upload-error-report__header").simulate("click");
     expect(
@@ -77,7 +77,7 @@ describe("Component: UploadErrorRow", () => {
     expect(
       wrapper.find(".upload-error-report__arrow").hasClass("down")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(5);
+    expect(wrapper.find(UploadErrorRow).length).toBe(7);
   });
 
   it("renders an 'incorrect_value_in_row' error report correctly", () => {
@@ -102,7 +102,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--incorrect_value_in_row")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(5);
+    expect(wrapper.find(UploadErrorRow).length).toBe(7);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Index",
       data: incorrectValueInRow.index
@@ -118,25 +118,39 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-1"
     );
     expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
-      label: "JSON",
-      data: incorrectValueInRow.json
+      label: "Object Id",
+      data: incorrectValueInRow.object_id
     });
     expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-2"
     );
     expect(wrapper.find(UploadErrorRow).get(3).props).toEqual({
-      label: "Excel",
-      data: incorrectValueInRow.excel
+      label: "Label",
+      data: incorrectValueInRow.label
     });
     expect(wrapper.find(UploadErrorRow).get(3).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-3"
     );
     expect(wrapper.find(UploadErrorRow).get(4).props).toEqual({
-      label: "Message",
-      data: incorrectValueInRow.message
+      label: "JSON",
+      data: incorrectValueInRow.json
     });
     expect(wrapper.find(UploadErrorRow).get(4).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-4"
+    );
+    expect(wrapper.find(UploadErrorRow).get(5).props).toEqual({
+      label: "Excel",
+      data: incorrectValueInRow.excel
+    });
+    expect(wrapper.find(UploadErrorRow).get(5).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-5"
+    );
+    expect(wrapper.find(UploadErrorRow).get(6).props).toEqual({
+      label: "Message",
+      data: incorrectValueInRow.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(6).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-6"
     );
   });
 
@@ -162,7 +176,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--paren_error")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(3);
+    expect(wrapper.find(UploadErrorRow).length).toBe(4);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Char. Index",
       data: parenError.character_index
@@ -178,11 +192,18 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-1"
     );
     expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
-      label: "Message",
-      data: parenError.message
+      label: "Label",
+      data: parenError.label
     });
     expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-2"
+    );
+    expect(wrapper.find(UploadErrorRow).get(3).props).toEqual({
+      label: "Message",
+      data: parenError.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(3).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-3"
     );
   });
 
@@ -208,7 +229,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--incorrectly_formatted_dbq_id")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(3);
+    expect(wrapper.find(UploadErrorRow).length).toBe(4);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Object Id",
       data: incorrectlyFormattedDbqId.object_id
@@ -217,18 +238,25 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-0"
     );
     expect(wrapper.find(UploadErrorRow).get(1).props).toEqual({
-      label: "DBQ Id",
-      data: incorrectlyFormattedDbqId.formatted_dbq_id
+      label: "Label",
+      data: incorrectlyFormattedDbqId.label
     });
     expect(wrapper.find(UploadErrorRow).get(1).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-1"
     );
     expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
-      label: "Message",
-      data: incorrectlyFormattedDbqId.message
+      label: "DBQ Id",
+      data: incorrectlyFormattedDbqId.formatted_dbq_id
     });
     expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-2"
+    );
+    expect(wrapper.find(UploadErrorRow).get(3).props).toEqual({
+      label: "Message",
+      data: incorrectlyFormattedDbqId.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(3).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-3"
     );
   });
 
@@ -254,7 +282,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--no_dbq_logical_combo")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(2);
+    expect(wrapper.find(UploadErrorRow).length).toBe(3);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Object Id",
       data: noDbqLogicalCombo.object_id
@@ -263,11 +291,18 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-0"
     );
     expect(wrapper.find(UploadErrorRow).get(1).props).toEqual({
-      label: "Message",
-      data: noDbqLogicalCombo.message
+      label: "Label",
+      data: noDbqLogicalCombo.label
     });
     expect(wrapper.find(UploadErrorRow).get(1).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-1"
+    );
+    expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
+      label: "Message",
+      data: noDbqLogicalCombo.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-2"
     );
   });
 
@@ -293,7 +328,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--dbq_logical_combo_error")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(3);
+    expect(wrapper.find(UploadErrorRow).length).toBe(4);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Index",
       data: dbqLogicalComboError.index
@@ -309,11 +344,18 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-1"
     );
     expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
-      label: "Message",
-      data: dbqLogicalComboError.message
+      label: "Label",
+      data: dbqLogicalComboError.label
     });
     expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-2"
+    );
+    expect(wrapper.find(UploadErrorRow).get(3).props).toEqual({
+      label: "Message",
+      data: dbqLogicalComboError.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(3).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-3"
     );
   });
 
@@ -371,7 +413,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--unmatched_parens")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(3);
+    expect(wrapper.find(UploadErrorRow).length).toBe(4);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Object Id",
       data: unmatchedParens.object_id
@@ -380,18 +422,25 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-0"
     );
     expect(wrapper.find(UploadErrorRow).get(1).props).toEqual({
-      label: "Positions",
-      data: unmatchedParens.list_of_positions.join(", ")
+      label: "Label",
+      data: unmatchedParens.label
     });
     expect(wrapper.find(UploadErrorRow).get(1).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-1"
     );
     expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
-      label: "Message",
-      data: unmatchedParens.message
+      label: "Positions",
+      data: unmatchedParens.list_of_positions.join(", ")
     });
     expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-2"
+    );
+    expect(wrapper.find(UploadErrorRow).get(3).props).toEqual({
+      label: "Message",
+      data: unmatchedParens.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(3).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-3"
     );
   });
 
@@ -419,7 +468,7 @@ describe("Component: UploadErrorRow", () => {
         .find(".upload-error-report__body")
         .hasClass("upload-error-report__body--mark_for_complexity_is_unchecked")
     ).toBeTruthy();
-    expect(wrapper.find(UploadErrorRow).length).toBe(2);
+    expect(wrapper.find(UploadErrorRow).length).toBe(3);
     expect(wrapper.find(UploadErrorRow).get(0).props).toEqual({
       label: "Object Id",
       data: markForComplexityIsUnchecked.object_id
@@ -428,11 +477,18 @@ describe("Component: UploadErrorRow", () => {
       "upload-error-report-key-stuff.xlsx-1-0"
     );
     expect(wrapper.find(UploadErrorRow).get(1).props).toEqual({
-      label: "Message",
-      data: markForComplexityIsUnchecked.message
+      label: "Label",
+      data: markForComplexityIsUnchecked.label
     });
     expect(wrapper.find(UploadErrorRow).get(1).key).toEqual(
       "upload-error-report-key-stuff.xlsx-1-1"
+    );
+    expect(wrapper.find(UploadErrorRow).get(2).props).toEqual({
+      label: "Message",
+      data: markForComplexityIsUnchecked.message
+    });
+    expect(wrapper.find(UploadErrorRow).get(2).key).toEqual(
+      "upload-error-report-key-stuff.xlsx-1-2"
     );
   });
 });

--- a/src/components/UploadPage/components/UploadErrorReport/UploadErrorReport.tsx
+++ b/src/components/UploadPage/components/UploadErrorReport/UploadErrorReport.tsx
@@ -43,11 +43,16 @@ const UploadErrorReport: React.FC<Props> = ({
           />
           <UploadErrorRow
             key={`upload-error-report-key-${filename}-${fileReportIndex}-1`}
+            label={ErrorFieldLabels.label}
+            data={errorReport.label}
+          />
+          <UploadErrorRow
+            key={`upload-error-report-key-${filename}-${fileReportIndex}-2`}
             label={ErrorFieldLabels.list_of_positions}
             data={errorReport.list_of_positions.join(", ")}
           />
           <UploadErrorRow
-            key={`upload-error-report-key-${filename}-${fileReportIndex}-2`}
+            key={`upload-error-report-key-${filename}-${fileReportIndex}-3`}
             label={ErrorFieldLabels.message}
             data={errorReport.message}
           />

--- a/src/models/FileReport.tsx
+++ b/src/models/FileReport.tsx
@@ -12,6 +12,8 @@ export type FileReport = {
  */
 export interface IncorrectValueInRow {
   error_type: "incorrect_value_in_row";
+  object_id: string;
+  label: string;
   column_name: string;
   index: number;
   excel: string;
@@ -23,6 +25,7 @@ export interface ParenError {
   error_type: "paren_error";
   character_index: number;
   object_id: string;
+  label: string;
   message: string;
 }
 
@@ -30,12 +33,14 @@ export interface IncorrectlyFormattedDbqId {
   error_type: "incorrectly_formatted_dbq_id";
   formatted_dbq_id: string;
   object_id: string;
+  label: string;
   message: string;
 }
 
 export interface NoDbqLogicalCombo {
   error_type: "no_dbq_logical_combo";
   object_id: string;
+  label: string;
   message: string;
 }
 
@@ -43,6 +48,7 @@ export interface DbqLogicalComboError {
   error_type: "dbq_logical_combo_error";
   index: number;
   object_id: string;
+  label: string;
   message: string;
 }
 
@@ -54,6 +60,7 @@ export interface WrongDocType {
 export interface UnmatchedParens {
   error_type: "unmatched_parens";
   object_id: string;
+  label: string;
   list_of_positions: Array<number>;
   message: string;
 }
@@ -61,6 +68,7 @@ export interface UnmatchedParens {
 export interface MarkForComplexityIsUnchecked {
   error_type: "mark_for_complexity_is_unchecked";
   object_id: string;
+  label: string;
   message: string;
 }
 
@@ -80,6 +88,7 @@ export type ErrorReport =
  */
 export enum ErrorFieldLabels {
   error_type = "Type",
+  label = "Label",
   character_index = "Char. Index",
   column_name = "Column",
   object_id = "Object Id",
@@ -114,11 +123,12 @@ const ErrorKeyOrderPreference: KeyedNumbersObject = {
   character_index: 2,
   column_name: 3,
   object_id: 4,
-  formatted_dbq_id: 5,
-  json: 6,
-  excel: 7,
-  list_of_positions: 8,
-  message: 9
+  label: 5,
+  formatted_dbq_id: 6,
+  json: 7,
+  excel: 8,
+  list_of_positions: 9,
+  message: 10
 };
 
 /**
@@ -141,6 +151,8 @@ export const MockUploadFileReport: FileReport = {
   exampleFileNameA: [
     {
       error_type: "incorrect_value_in_row",
+      object_id: "IncorrectValueInRowObjectId",
+      label: "Doh!",
       column_name: "Column B",
       index: 10,
       excel: "IncorrectValueInRow.xlsx",
@@ -151,17 +163,20 @@ export const MockUploadFileReport: FileReport = {
       error_type: "paren_error",
       character_index: 5,
       object_id: "ParenErrorObjectId",
+      label: "Ya got bumpkis!",
       message: "To infinity, and beyond!"
     },
     {
       error_type: "incorrectly_formatted_dbq_id",
       formatted_dbq_id: "Formatted DBQ",
       object_id: "IncorrectlyFormattedDBQId",
+      label: "(Scream!)",
       message: "There aren't anymore monkeys! That's the whole barrel!"
     },
     {
       error_type: "no_dbq_logical_combo",
       object_id: "NoDBQLogicalErrorCombo",
+      label: "Zut alors!",
       message: "This is falling with style!"
     }
   ],
@@ -170,6 +185,7 @@ export const MockUploadFileReport: FileReport = {
       error_type: "dbq_logical_combo_error",
       index: 15,
       object_id: "DBQLogicalComboError",
+      label: "Mama mia!",
       message: "You are a child's plaything!"
     },
     {
@@ -179,6 +195,7 @@ export const MockUploadFileReport: FileReport = {
     {
       error_type: "unmatched_parens",
       object_id: "UnmatchedParens",
+      label: "Waaaah!",
       list_of_positions: [1, 2, 3],
       message:
         "He ain’t the sharpest knife in the place where they keep the knives."
@@ -186,6 +203,7 @@ export const MockUploadFileReport: FileReport = {
     {
       error_type: "mark_for_complexity_is_unchecked",
       object_id: "MarkForComplexityIsUnchecked",
+      label: "Ay caramba!",
       message:
         "The word I'm searching for I can't say because there's preschool toys present."
     }


### PR DESCRIPTION
### Related tickets:
MCP-206.

### What's changing? Any breaking changes?
Changes the returned values per the client's request. 

### Manual test cases?
- Step 1
Run the tests with `yarn test` and verify that they are all passing.

- Step 2
Start the server with `yarn start`. Be sure that the `.env` includes a variable for your backend, which should also be started. (probably `REACT_APP_MCP_DATA_MAPPING_UTIL=http://localhost:5000/`). Submit some files with errors (those at `sample-data` will work well). Check that they new include a "label" field.

### Any additional context/background?
*Requires the backend PR at https://github.com/amida-tech/mcp-data-mapping-utils/pull/63*

Relates to [MCP-206](https://jira.amida.com/browse/MCP-206)